### PR TITLE
fix: use supported version of cypress-image-snapshot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install --legacy-peer-deps
+    - run: npm install
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "cypress run --browser chrome"
   },
   "dependencies": {
-    "cypress-image-snapshot": "^4.0.1",
+    "@simonsmith/cypress-image-snapshot": "^9.1.0",
     "eslint-plugin-cypress": "^2.12.1",
     "@faker-js/faker": "^8.4.1",
     "pg": "^8.9.0",


### PR DESCRIPTION
The previously used version was unsupported, so switched to the forked version which is more or less actively maintained.

The issues with installing of the packages are not reproducible now.

BUT please let me know if there is any content we need to update in the Mate Academy platform to account for this change.